### PR TITLE
Hotkeys no longer trigger while text input field has focus

### DIFF
--- a/EditorExtensionsRedux/EditorExtensionsRedux.cs
+++ b/EditorExtensionsRedux/EditorExtensionsRedux.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 using System.Reflection;
 using KSP.IO;
+using KSP.UI.Screens;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
@@ -614,6 +615,13 @@ namespace EditorExtensionsRedux
             if (!validVersion)
                 return;
 
+            //if (editor.shipNameField.Focused || editor.shipDescriptionField.Focused)
+            //	return;
+            GameObject obj = EventSystem.current.currentSelectedGameObject;
+            bool inputFieldIsFocused = (obj != null && obj.GetComponent<TMPro.TMP_InputField>() != null && obj.GetComponent<TMPro.TMP_InputField>().isFocused);
+            if (inputFieldIsFocused)
+                return;
+
             //Boop: Override stock Angle Snap manipulation
             if ((Input.GetKeyDown(HotkeyEditor_toggleAngleSnapPrimary) || Input.GetKeyDown(HotkeyEditor_toggleAngleSnapSecondary)))
             {
@@ -738,12 +746,7 @@ namespace EditorExtensionsRedux
                 }
             }
 
-            //if (editor.shipNameField.Focused || editor.shipDescriptionField.Focused)
-            //	return;
-            GameObject obj = EventSystem.current.currentSelectedGameObject;
-            bool inputFieldIsFocused = (obj != null && obj.GetComponent<InputField>() != null && obj.GetComponent<InputField>().isFocused);
-            if (inputFieldIsFocused)
-                return;
+
             //ignore hotkeys while settings window is open
             //if (_settingsWindow != null && _settingsWindow.enabled)
             //	return;


### PR DESCRIPTION
Using the Search field or editing Name / Descriptions no longer activates hotkeys.