### PR TITLE
Fix issue #33 & minor visual issue

### DIFF
--- a/EditorExtensionsRedux/EditorExtensionsRedux.cs
+++ b/EditorExtensionsRedux/EditorExtensionsRedux.cs
@@ -2476,7 +2476,7 @@ editor.angleSnapSprite.gameObject.SetActive (false);
                     RefreshParts();
                     foreach (Part p in parts)
                     {
-                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode))
+                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode) && p.AllowAutoStruts() == true)
                         {
                             p.autoStrutMode = Part.AutoStrutMode.Grandparent;
                             p.ToggleAutoStrut();
@@ -2490,7 +2490,7 @@ editor.angleSnapSprite.gameObject.SetActive (false);
                     RefreshParts();
                     foreach (Part p in parts)
                     {
-                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode))
+                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode) && p.AllowAutoStruts() == true)
                         {
                             // First set off to get timers set properly with the toggle, then update to Grandparent
                             p.autoStrutMode = Part.AutoStrutMode.Root;
@@ -2507,7 +2507,7 @@ editor.angleSnapSprite.gameObject.SetActive (false);
                     RefreshParts();
                     foreach (Part p in parts)
                     {
-                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode))
+                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode) && p.AllowAutoStruts() == true)
                         {
                             // p.autoStrutMode = Part.AutoStrutMode.Heaviest;;
 
@@ -2526,7 +2526,7 @@ editor.angleSnapSprite.gameObject.SetActive (false);
                     RefreshParts();
                     foreach (Part p in parts)
                     {
-                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode))
+                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode) && p.AllowAutoStruts() == true)
                         {
                             // p.autoStrutMode = Part.AutoStrutMode.Root;
 

--- a/EditorExtensionsRedux/EditorExtensionsRedux.cs
+++ b/EditorExtensionsRedux/EditorExtensionsRedux.cs
@@ -2476,7 +2476,7 @@ editor.angleSnapSprite.gameObject.SetActive (false);
                     RefreshParts();
                     foreach (Part p in parts)
                     {
-                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode) && p.AllowAutoStruts() == true)
+                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode))
                         {
                             p.autoStrutMode = Part.AutoStrutMode.Grandparent;
                             p.ToggleAutoStrut();

--- a/EditorExtensionsRedux/FineAdjustWindow.cs
+++ b/EditorExtensionsRedux/FineAdjustWindow.cs
@@ -63,7 +63,7 @@ namespace EditorExtensionsRedux
 					_windowTitle = _windowTitle + " Active";
 					tstyle.normal.textColor = Color.yellow;
 				}
-				_windowRect.yMax = _windowRect.yMin;
+				//_windowRect.yMax = _windowRect.yMin;
 				_windowRect = ClickThruBlocker.GUILayoutWindow (this.GetInstanceID (), _windowRect, WindowContent, _windowTitle, tstyle);
 			}
 		}


### PR DESCRIPTION
Added an additional logical operator to prevent autostruts beeing applied to parts which don't allow them.
Also, fixed a visual issue regarding the 'Fine Adjustment' window. It's no longer flickering when dragging it around.