### PR TITLE
Amending 4x4cheessecake fixes for the Mass AutoStrut problem.

### DIFF
--- a/EditorExtensionsRedux/EditorExtensionsRedux.cs
+++ b/EditorExtensionsRedux/EditorExtensionsRedux.cs
@@ -2476,10 +2476,15 @@ editor.angleSnapSprite.gameObject.SetActive (false);
                     RefreshParts();
                     foreach (Part p in parts)
                     {
-                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode))
+                        if (!doNotMessWithAutoStrutModes.Contains(p.autoStrutMode)) try
                         {
                             p.autoStrutMode = Part.AutoStrutMode.Grandparent;
                             p.ToggleAutoStrut();
+                        }
+                        catch(Exception e)
+                        {
+                            p.autoStrutMode = Part.AutoStrutMode.Off;
+                            Debug.LogException(e);
                         }
                     }
                     OSDMessage("Autostruts turned OFF for all current Parts in Vessel (except forced).");


### PR DESCRIPTION
 This allow to "recover" a mangled vessel.