### PR TITLE
Fire GameEvent on symmetryMode change.

### DIFF
--- a/EditorExtensionsRedux/EditorExtensionsRedux.cs
+++ b/EditorExtensionsRedux/EditorExtensionsRedux.cs
@@ -869,6 +869,7 @@ namespace EditorExtensionsRedux
                     {
                         editor.symmetryMode = 1;
                     }
+                    GameEvents.onEditorSymmetryModeChange.Fire(editor.symmetryMode);
                     return;
                 }
                 else if (ExtendedInput.GetKey(GameSettings.MODIFIER_KEY.primary) || ExtendedInput.GetKey(GameSettings.MODIFIER_KEY.secondary))
@@ -884,6 +885,7 @@ namespace EditorExtensionsRedux
                             preResetSymmetryMode = editor.symmetryMode;
                         editor.symmetryMode = 0;
                     }
+                    GameEvents.onEditorSymmetryModeChange.Fire(editor.symmetryMode);
                 }
                 else
                 {
@@ -902,6 +904,7 @@ namespace EditorExtensionsRedux
                     {
                         editor.symmetryMode = 1;
                     }
+                    GameEvents.onEditorSymmetryModeChange.Fire(editor.symmetryMode);
                     return;
                 }
             }

--- a/EditorExtensionsRedux/EditorExtensionsRedux.csproj
+++ b/EditorExtensionsRedux/EditorExtensionsRedux.csproj
@@ -47,7 +47,7 @@
     </CustomCommands>
     <ConsolePause>false</ConsolePause>
     <ErrorReport>prompt</ErrorReport>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyVersion.cs">


### PR DESCRIPTION
Fixes #45
I'm not quite sure what your method is for the versioning so I'll leave that part to you if this pull request were to be accepted.
Thanks in advance!

- Changed debugging symbol mode to portable to facilitate attaching the VisualStudio unity debugger.
- Updated Override stock Symmetry manipulation to fire the missing event.

