### PR TITLE
Remove garbage data from version file

### DIFF
--- a/EditorExtensionsRedux.version
+++ b/EditorExtensionsRedux.version
@@ -17,10 +17,5 @@
     "MAJOR": 1,
     "MINOR": 11,
     "PATCH": 1
-  },
-  "KSP_VERSION_MIN": {
-    "MAJOR": 1,
-    "MINOR": 12,
-    "PATCH": 99
   }
 }


### PR DESCRIPTION
Hi @linuxgurugamer,

68771789b920e017da766c0a91f82031b110bf2c added a duplicate `KSP_VERSION_MIN` property that incorrectly set the min to `1.12.99`; when the minimum greater than every version that was ever released, _no_ actual version is ever compatible. This is preventing this version from being added to CKAN.

![image](https://github.com/user-attachments/assets/764f5dd4-e09f-489c-aff8-ce7da88b8d4e)

This PR removes that. Cheers!
